### PR TITLE
Move sub-layout profile into sticky content header

### DIFF
--- a/src/app/[locale]/(sub-default)/layout.tsx
+++ b/src/app/[locale]/(sub-default)/layout.tsx
@@ -1,11 +1,17 @@
 import SubSideHeader from "@/components/layout/header/subSide/SubSideHeader";
+import AuthArea from "@/components/layout/header/auth/AuthArea";
 import styles from "@/app/[locale]/(sub-default)/subLayout.module.css";
 
 export default function SubLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className={styles.layout}>
       <SubSideHeader />
-      <main className={styles.contents}>{children}</main>
+      <main className={styles.contents}>
+        <header className={styles.contentsHeader}>
+          <AuthArea />
+        </header>
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/app/[locale]/(sub-default)/subLayout.module.css
+++ b/src/app/[locale]/(sub-default)/subLayout.module.css
@@ -10,8 +10,21 @@
   padding: 20px 16px 40px;
 }
 
+.contentsHeader {
+  position: sticky;
+  top: 12px;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
 @media (max-width: 1024px) {
   .layout {
     flex-direction: column;
+  }
+
+  .contentsHeader {
+    top: 8px;
   }
 }

--- a/src/components/layout/header/subSide/SubSideHeader.tsx
+++ b/src/components/layout/header/subSide/SubSideHeader.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 
 import { Link, usePathname } from "@/i18n/routing";
-import AuthArea from "@/components/layout/header/auth/AuthArea";
 import logo from "../../../../../public/icons/logo/logo-for-yps.svg";
 import styles from "@/components/layout/header/subSide/subSideHeader.module.css";
 
@@ -53,10 +52,6 @@ export default function SubSideHeader() {
             })}
           </ul>
         </nav>
-      </div>
-
-      <div className={styles.bottomArea}>
-        <AuthArea />
       </div>
     </aside>
   );

--- a/src/components/layout/header/subSide/subSideHeader.module.css
+++ b/src/components/layout/header/subSide/subSideHeader.module.css
@@ -2,8 +2,6 @@
   position: sticky;
   top: 0;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
   width: 220px;
   min-width: 220px;
   height: 100vh;
@@ -40,11 +38,6 @@
   color: #202431;
 }
 
-.bottomArea {
-  display: flex;
-  align-items: center;
-}
-
 @media (max-width: 1024px) {
   .sidebar {
     position: static;
@@ -77,10 +70,6 @@
     border-radius: 9999px;
     font-size: 14px;
   }
-
-  .bottomArea {
-    padding-bottom: 0;
-  }
 }
 
 @media (max-width: 768px) {
@@ -88,10 +77,5 @@
     flex-direction: column;
     align-items: flex-start;
     row-gap: 12px;
-  }
-
-  .bottomArea {
-    width: 100%;
-    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
### Motivation
- Keep the profile/login UI visible while scrolling by moving it from the sidebar into the main content area and making it sticky.
- Simplify the sidebar so it only contains logo and navigation when profile is rendered elsewhere.
- Improve responsive behavior by aligning the profile to the right of the content header on smaller viewports.

### Description
- Removed `AuthArea` rendering from the sidebar component in `src/components/layout/header/subSide/SubSideHeader.tsx` so the side header only shows logo and menu.
- Added a new header inside the sub-layout main content in `src/app/[locale]/(sub-default)/layout.tsx` that renders `AuthArea` to host the profile/login UI.
- Added `.contentsHeader` styles in `src/app/[locale]/(sub-default)/subLayout.module.css` with `position: sticky`, `top` offsets, `z-index`, and right alignment for the profile area.
- Simplified sidebar CSS by removing `bottomArea` styles and the `justify-content: space-between` layout in `src/components/layout/header/subSide/subSideHeader.module.css`.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with pages generated and no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2520121b8833289679610613682c6)